### PR TITLE
Add hcloud_firewall table to steampipe-plugin-hcloud

### DIFF
--- a/docs/tables/hcloud_firewall.md
+++ b/docs/tables/hcloud_firewall.md
@@ -1,0 +1,81 @@
+---
+title: "Steampipe Table: hcloud_firewall - Query Hetzner Cloud Firewalls using SQL"
+description: "Allows users to query Firewalls in Hetzner Cloud, specifically the firewall ID, name, and other related information."
+---
+
+# Table: hcloud_firewall - Query Hetzner Cloud Firewalls using SQL
+
+Hetzner Cloud provides firewall management for securing access to cloud resources. Firewalls consist of configurable rules and can be applied to servers either directly or via label selectors. They help enforce network-level security policies to limit unauthorized access.
+
+## Table Usage Guide
+
+The `hcloud_firewall` table allows you to retrieve and explore information about firewalls configured in your Hetzner Cloud environment. As a system administrator or DevOps engineer, you can use this table to audit firewall usage, analyze rule configurations, and identify servers without firewall protection.
+
+## Examples
+
+### List all firewalls
+Explore all available firewalls to understand what exists in your cloud account and how each is identified.
+
+```sql+postgres
+select
+  *
+from
+  hcloud_firewall
+order by
+  name;
+```
+
+```sql+sqlite
+select
+  *
+from
+  hcloud_firewall
+order by
+  name;
+```
+
+### Get firewall by name
+Retrieve the specific configuration of a named firewall to inspect its rules and applied targets.
+
+```sql+postgres
+select
+  *
+from
+  hcloud_firewall
+where
+  name = 'firewall1;
+```
+
+```sql+sqlite
+select
+  *
+from
+  hcloud_firewall
+where
+  name = 'firewall1;
+```
+
+### List firewalls not applied to any resource
+Find firewalls that are currently not used, so you can clean them up or reassign them to the appropriate servers.
+
+```sql+postgres
+select
+  id,
+  name,
+  applied_to
+from
+  hcloud_firewall
+where
+  applied_to is null;
+```
+
+```sql+sqlite
+select
+  id,
+  name,
+  applied_to
+from
+  hcloud_firewall
+where
+  applied_to is null;
+```

--- a/hcloud/plugin.go
+++ b/hcloud/plugin.go
@@ -20,6 +20,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		TableMap: map[string]*plugin.Table{
 			"hcloud_action":          tableHcloudAction(ctx),
 			"hcloud_datacenter":      tableHcloudDataCenter(ctx),
+			"hcloud_firewall":        tableHcloudFirewall(ctx),
 			"hcloud_image":           tableHcloudImage(ctx),
 			"hcloud_location":        tableHcloudLocation(ctx),
 			"hcloud_network":         tableHcloudNetwork(ctx),
@@ -28,7 +29,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"hcloud_server_type":     tableHcloudServerType(ctx),
 			"hcloud_ssh_key":         tableHcloudSSHKey(ctx),
 			"hcloud_volume":          tableHcloudVolume(ctx),
-			"hcloud_firewall":        tableHcloudFirewall(ctx),
 		},
 	}
 	return p

--- a/hcloud/plugin.go
+++ b/hcloud/plugin.go
@@ -28,6 +28,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"hcloud_server_type":     tableHcloudServerType(ctx),
 			"hcloud_ssh_key":         tableHcloudSSHKey(ctx),
 			"hcloud_volume":          tableHcloudVolume(ctx),
+			"hcloud_firewall":        tableHcloudFirewall(ctx),
 		},
 	}
 	return p

--- a/hcloud/table_hcloud_firewall.go
+++ b/hcloud/table_hcloud_firewall.go
@@ -12,7 +12,7 @@ import (
 func tableHcloudFirewall(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "hcloud_firewall",
-		Description: "Firewall rules in Hetzner Cloud.",
+		Description: "Firewall resources in Hetzner Cloud.",
 		List: &plugin.ListConfig{
 			KeyColumns: plugin.OptionalColumns([]string{"name"}),
 			Hydrate:    listFirewall,

--- a/hcloud/table_hcloud_firewall.go
+++ b/hcloud/table_hcloud_firewall.go
@@ -18,7 +18,7 @@ func tableHcloudFirewall(ctx context.Context) *plugin.Table {
 			Hydrate:    listFirewall,
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.AnyColumn([]string{"id"}),
+			KeyColumns: plugin.SingleColumn("id"),
 			Hydrate:    getFirewall,
 		},
 		Columns: []*plugin.Column{

--- a/hcloud/table_hcloud_firewall.go
+++ b/hcloud/table_hcloud_firewall.go
@@ -18,7 +18,7 @@ func tableHcloudFirewall(ctx context.Context) *plugin.Table {
 			Hydrate:    listFirewall,
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.AnyColumn([]string{"name"}),
+			KeyColumns: plugin.AnyColumn([]string{"id"}),
 			Hydrate:    getFirewall,
 		},
 		Columns: []*plugin.Column{
@@ -31,7 +31,6 @@ func tableHcloudFirewall(ctx context.Context) *plugin.Table {
 		},
 	}
 }
-
 
 func listFirewall(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	conn, err := connect(ctx, d)
@@ -70,15 +69,17 @@ func getFirewall(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 		plugin.Logger(ctx).Error("hcloud_firewall.getFirewall", "connection_error", err)
 		return nil, err
 	}
-	var item *hcloudgo.Firewall
-	var resp *hcloudgo.Response
-	if d.EqualsQuals["name"] != nil {
-		name := d.EqualsQuals["name"].GetStringValue()
-		item, resp, err = conn.Firewall.GetByName(ctx, name)
+
+	id := int(d.EqualsQuals["id"].GetInt64Value())
+	if id == 0 {
+		return nil, nil
 	}
+
+	item, resp, err := conn.Firewall.GetByID(ctx, id)
 	if err != nil {
 		plugin.Logger(ctx).Error("hcloud_firewall.getFirewall", "query_error", err, "resp", resp)
 		return nil, err
 	}
-	return item, err
+
+	return item, nil
 }

--- a/hcloud/table_hcloud_firewall.go
+++ b/hcloud/table_hcloud_firewall.go
@@ -1,0 +1,84 @@
+package hcloud
+
+import (
+	"context"
+
+	hcloudgo "github.com/hetznercloud/hcloud-go/hcloud"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+func tableHcloudFirewall(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "hcloud_firewall",
+		Description: "Firewall rules in Hetzner Cloud.",
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.OptionalColumns([]string{"name"}),
+			Hydrate:    listFirewall,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AnyColumn([]string{"name"}),
+			Hydrate:    getFirewall,
+		},
+		Columns: []*plugin.Column{
+			{Name: "id", Type: proto.ColumnType_INT, Description: "ID of the Firewall."},
+			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the Firewall."},
+			{Name: "labels", Type: proto.ColumnType_JSON, Description: "User-defined labels."},
+			{Name: "created", Type: proto.ColumnType_TIMESTAMP, Description: "Creation time of the Firewall."},
+			{Name: "rules", Type: proto.ColumnType_JSON, Description: "Firewall rules."},
+			{Name: "applied_to", Type: proto.ColumnType_JSON, Description: "Resources this firewall is applied to."},
+		},
+	}
+}
+
+
+func listFirewall(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	conn, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hcloud_firewall.listFirewall", "connection_error", err)
+		return nil, err
+	}
+
+	opts := hcloudgo.FirewallListOpts{ListOpts: hcloudgo.ListOpts{Page: 1, PerPage: 50}}
+
+	if d.EqualsQuals["name"] != nil {
+		opts.Name = d.EqualsQuals["name"].GetStringValue()
+	}
+
+	for {
+		items, resp, err := conn.Firewall.List(ctx, opts)
+		if err != nil {
+			plugin.Logger(ctx).Error("hcloud_firewall.listFirewall", "query_error", err)
+			return nil, err
+		}
+		for _, i := range items {
+			d.StreamListItem(ctx, i)
+		}
+		opts.ListOpts.Page++
+		if resp.Meta.Pagination.Page >= resp.Meta.Pagination.LastPage {
+			break
+		}
+	}
+
+	return nil, nil
+}
+
+func getFirewall(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	conn, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("hcloud_firewall.getFirewall", "connection_error", err)
+		return nil, err
+	}
+	var item *hcloudgo.Firewall
+	var resp *hcloudgo.Response
+	if d.EqualsQuals["name"] != nil {
+		name := d.EqualsQuals["name"].GetStringValue()
+		item, resp, err = conn.Firewall.GetByName(ctx, name)
+	}
+	if err != nil {
+		plugin.Logger(ctx).Error("hcloud_firewall.getFirewall", "query_error", err, "resp", resp)
+		return nil, err
+	}
+	return item, err
+}


### PR DESCRIPTION
This PR introduces a new table, hcloud_firewall, to the steampipe-plugin-hcloud. It enables users to query Firewall resources directly from Hetzner Cloud via Steampipe, including associated servers and labels for each firewall

